### PR TITLE
16bit encoder and icc profile support

### DIFF
--- a/examples/decode16_encode16.py
+++ b/examples/decode16_encode16.py
@@ -18,11 +18,13 @@ with open(local_source, 'rb') as f:
 
 dec = jxlpy.JXLPyDecoder(fc)
 info = dec.get_info()
+icc = dec.get_icc_profile()
 colorspace = dec.get_colorspace()
 
 print('\n=== DECODING SOURCE IMAGE ===\n')
 print('Read information about image:', info)
 print('Colorspace:', colorspace)
+print('ICC:', icc)
 
 while True:
 
@@ -32,7 +34,7 @@ while True:
     
     print('Beginning of Image data:', list(frame[:99]))
 
-    enc = jxlpy.JXLPyEncoder(quality=100, colorspace='RGB', size=(info.get('xsize'), info.get('ysize')), effort=3, bit_depth=info.get('bits_per_sample'), alpha_bit_depth=info.get('alpha_bits'))
+    enc = jxlpy.JXLPyEncoder(quality=100, colorspace='RGB', size=(info.get('xsize'), info.get('ysize')), effort=3, bit_depth=info.get('bits_per_sample'), alpha_bit_depth=info.get('alpha_bits'), icc_profile=icc)
     enc.add_frame(frame)
 
     with open('test16.jxl', 'wb') as f:

--- a/examples/decode16_encode16.py
+++ b/examples/decode16_encode16.py
@@ -1,0 +1,61 @@
+import requests
+import jxlpy
+import os
+
+remote_source = 'https://people.csail.mit.edu/ericchan/hdr/jxl_images/20140606_102418_IMGP0297.jxl'
+local_source = os.path.basename(remote_source)
+
+# download image if necessary
+if not os.path.exists(local_source):
+    r = requests.get(remote_source)
+    assert(r.status_code == 200)
+    with open(local_source, 'wb') as f:
+        f.write(r.content)
+
+with open(local_source, 'rb') as f:
+    fc = f.read()
+
+
+dec = jxlpy.JXLPyDecoder(fc)
+info = dec.get_info()
+colorspace = dec.get_colorspace()
+
+print('\n=== DECODING SOURCE IMAGE ===\n')
+print('Read information about image:', info)
+print('Colorspace:', colorspace)
+
+while True:
+
+    frame = dec.get_frame()
+    if frame is None:
+        break
+    
+    print('Beginning of Image data:', list(frame[:99]))
+
+    enc = jxlpy.JXLPyEncoder(quality=100, colorspace='RGB', size=(info.get('xsize'), info.get('ysize')), effort=3, bit_depth=info.get('bits_per_sample'), alpha_bit_depth=info.get('alpha_bits'))
+    enc.add_frame(frame)
+
+    with open('test16.jxl', 'wb') as f:
+        f.write(enc.get_output())
+
+
+# decode just encoded image
+with open('test16.jxl', 'rb') as f:
+    fc = f.read()
+
+dec = jxlpy.JXLPyDecoder(fc)
+info = dec.get_info()
+colorspace = dec.get_colorspace()
+
+print('\n=== DECODING RE-ENCODED IMAGE ===\n')
+print('Read information about image:', info)
+print('Colorspace:', colorspace)
+
+while True:
+
+    frame = dec.get_frame()
+    if frame is None:
+        break
+    
+    print('Beginning of Image data:', list(frame[:99]))
+

--- a/jxlpy/JXLImagePlugin.py
+++ b/jxlpy/JXLImagePlugin.py
@@ -29,6 +29,9 @@ class JXLImageFile(ImageFile.ImageFile):
         self._size = (self._jxlinfo['xsize'], self._jxlinfo['ysize'])
         self.is_animated = self._jxlinfo['have_animation']
         self._mode = self.rawmode = self._decoder.get_colorspace()
+        
+        self.info['icc'] = self._decoder.get_icc_profile()
+        
         self.tile = []
 
 
@@ -73,6 +76,7 @@ def _save(im, fp, filename, save_all=False):
         raise NotImplementedError('Only RGB, RGBA, L, LA are supported.')
 
     info = im.encoderinfo.copy()
+    icc_profile = info.get("icc_profile") or b""
     
     # default quality is 70
     quality = info.get('quality', 70)
@@ -86,7 +90,7 @@ def _save(im, fp, filename, save_all=False):
     enc = jxlpy.JXLPyEncoder(
         quality=quality, size=im.size, colorspace=im.mode, 
         effort=effort, decoding_speed=decoding_speed, use_container=use_container,
-        num_threads=num_threads
+        num_threads=num_threads, icc_profile=icc_profile
     )
     
     enc.add_frame(im.tobytes())


### PR DESCRIPTION
This pull request adds support for 16 bit jxl image encoding.
It's only accessible directly with jxlpy since Pillow doesn't seem to support 16 bit color images.
ICC profiles support has been introduced by Nickolay Belofastow and is also integrated within Pillow plugin. This should enable proper color interpretation of high bit-depth HDR images.