### PR TITLE
Require pillow 10.0.1 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ It also provides support for Pillow via plugin.
 ```shell
 $ pip install jxlpy
 ```
+or
+```shell
+$ pip install jxlpy[pillow]
+```
+if you intend to use the Pillow extension.
 
 ## Build it yourself
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ jxlpy_ext = Extension(
 
 
 setup(name='jxlpy',
-      version='0.9.4',
+      version='0.9.5',
       description='JPEG XL integration in Python',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -33,7 +33,7 @@ setup(name='jxlpy',
       },
       include_package_data=True,
       install_requires=['cython'],
-      extras_require={'pillow': ['Pillow']},
+      extras_require={'pillow>=10.1.0': ['Pillow']},
       python_requires='>=3.4',
       ext_modules=cythonize([jxlpy_ext]),
       classifiers=[


### PR DESCRIPTION
From https://github.com/olokelo/jxlpy/issues/21, https://github.com/olokelo/jxlpy/issues/22, it seems like a recent pillow is needed.

I bisected and confirmed that at least pillow 10.0.1 is required for the plugin to work.

Making that explicit and bumping version.