### PR TITLE
Support older pillows

### DIFF
--- a/jxlpy/JXLImagePlugin.py
+++ b/jxlpy/JXLImagePlugin.py
@@ -30,7 +30,11 @@ class JXLImageFile(ImageFile.ImageFile):
         self._size = (self._jxlinfo['xsize'], self._jxlinfo['ysize'])
         self.is_animated = self._jxlinfo['have_animation']
         self.n_frames = self._decoder.get_n_frames()
-        self._mode = self.rawmode = self._decoder.get_colorspace()
+        mode = self._decoder.get_colorspace()
+        try:
+            self.mode = self.rawmode = mode
+        except AttributeError:
+            self._mode = self.rawmode = mode
 
         self.info['icc'] = self._decoder.get_icc_profile()
         

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ jxlpy_ext = Extension(
 
 
 setup(name='jxlpy',
-      version='0.9.4',
+      version='0.9.5',
       description='JPEG XL integration in Python',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
From https://github.com/olokelo/jxlpy/issues/18, https://github.com/olokelo/jxlpy/issues/21, https://github.com/olokelo/jxlpy/issues/22, it seems like a recent pillow is needed.

As indicated by https://github.com/olokelo/jxlpy/pull/19, there was a breaking change to the `.mode` property in PIL 10.1.0.

This patch ensures that we don't have to drop support for older Pillow versions, following the pattern in 
https://github.com/fdintino/pillow-avif-plugin/blob/aa7ac7f74c84ac409ad8668cd25f466334fd3753/src/pillow_avif/AvifImagePlugin.py#L72-L75.